### PR TITLE
Add a slug to events, and expose it in event presenter

### DIFF
--- a/api/v1/entity/event.rb
+++ b/api/v1/entity/event.rb
@@ -30,6 +30,10 @@ module VLCTechHub
         def hashtag
           @object['hashtag']
         end
+
+        def slug
+          @object['slug']
+        end
       end
     end
   end

--- a/services/event/repository.rb
+++ b/services/event/repository.rb
@@ -38,13 +38,14 @@ module VLCTechHub
       end
 
       def insert(new_event)
+        new_event.stringify_keys!
         id = BSON::ObjectId.new
         created_at = id.generation_time
-        new_event[:_id] = id
-        new_event[:published] = false
-        new_event[:publish_id] = SecureRandom.uuid
-        new_event[:created_at] = created_at
-        new_event[:slug] = "#{new_event[:title].downcase.strip.gsub(/[^\w-]/, '-')}-#{created_at.to_i.to_s(16)}".squeeze('-')
+        new_event['_id'] = id
+        new_event['published'] = false
+        new_event['publish_id'] = SecureRandom.uuid
+        new_event['created_at'] = created_at
+        new_event['slug'] = "#{new_event['title'].downcase.strip.gsub(/[^\w-]/, '-')}-#{created_at.to_i.to_s(16)}".squeeze('-')
         db['events'].insert_one(new_event)
         new_event
       end

--- a/services/job/repository.rb
+++ b/services/job/repository.rb
@@ -27,8 +27,8 @@ module VLCTechHub
         job_offer['published'] = false
         job_offer['publish_id'] = SecureRandom.uuid
         job_offer['created_at'] = DateTime.now
-        id = collection.insert_one(job_offer).inserted_id
-        collection.find( {_id: id} ).first
+        collection.insert_one(job_offer)
+        job_offer
       end
 
       def publish(uuid)

--- a/services/job/repository.rb
+++ b/services/job/repository.rb
@@ -23,6 +23,7 @@ module VLCTechHub
       end
 
       def insert(job_offer)
+        job_offer.stringify_keys!
         job_offer['published'] = false
         job_offer['publish_id'] = SecureRandom.uuid
         job_offer['created_at'] = DateTime.now


### PR DESCRIPTION
In order to resolve #8, a 'slug' attribute is added when inserting an event.

At the moment the ending hash is the timestamp associated to event celebration in hex format, but I'm not sure if it is a suitable option.

If one event is inserted twice, i.e. duplicated, the slug will be the same for both and it wouldn't be suitable as a 'readable id'.

On the other hand, it would be reasonable that only one of the duplicated events would be published, so we could check that when looking for an event with its slug.

Other option would be to use a substring from the 'publish_id' (first or last block, for example) so duplicated events will have different slugs.

Any thoughts @hell03610?
