### PR TITLE
Unpublish endpoint for jobs

### DIFF
--- a/api/v1/entity/job_offer.rb
+++ b/api/v1/entity/job_offer.rb
@@ -47,6 +47,11 @@ module VLCTechHub
         def salary
           @object['salary']
         end
+
+        def secret
+          @object['secret']
+        end
+
       end
 
       class UnpublishedJobOffer < JobOffer

--- a/api/v1/jobs.rb
+++ b/api/v1/jobs.rb
@@ -50,7 +50,19 @@ module VLCTechHub
 
               job = jobs.find_by_uuid(params[:uuid])
               VLCTechHub::Job::Mailer.broadcast(job)
+              VLCTechHub::Job::Mailer.published(job)
               VLCTechHub::Job::Twitter.new_job(job)
+
+              present :job, job, with: JobOffer
+            end
+          end
+
+          resource 'unpublish' do
+            get '/:uuid/secret/:secret' do
+              unpublished = jobs.unpublish(params[:uuid],params[:secret])
+              error!('404 Not found', 404) unless unpublished
+
+              job = jobs.find_by_uuid(params[:uuid])
 
               present :job, job, with: JobOffer
             end

--- a/app/base/repository.rb
+++ b/app/base/repository.rb
@@ -31,7 +31,7 @@ module VLCTechHub
 
       def unpublish(uuid, secret)
         result = collection.update_one({ published: true, publish_id: uuid, secret: secret },
-                                       { "$set" => { published: false } } )
+                                       { "$set" => { published: false, published_at: nil } } )
         was_updated = (result.n == 1)
       end
 

--- a/app/base/repository.rb
+++ b/app/base/repository.rb
@@ -29,6 +29,12 @@ module VLCTechHub
         true
       end
 
+      def unpublish(uuid, secret)
+        result = collection.update_one({ published: true, publish_id: uuid, secret: secret },
+                                       { "$set" => { published: false } } )
+        was_updated = (result.n == 1)
+      end
+
       def remove_all
         collection.drop
         true

--- a/app/job/mailer.rb
+++ b/app/job/mailer.rb
@@ -46,6 +46,32 @@ module VLCTechHub
             end
           end
         end
+
+        def published(job)
+
+          return false if job['contact_email'].to_s.empty?
+
+          Mail.deliver do
+            to job['contact_email']
+            from 'VLCTechHub <vlctechhub@gmail.com>'
+            subject "[VLCTECHHUB] Publicado: #{job['title']}"
+
+            html_part do
+              content_type 'text/html; charset=UTF-8'
+              body "<h1>#{job['title']}</h1>" +
+                "<pre>#{job['description']}</pre>" +
+                "<p>Keywords: #{job['tags']}</p>" +
+                "<p>Company Name: #{job['company']['name']}</p>" +
+                "<p>Company Link: #{job['company']['link']}</p>" +
+                "<p>Company Twitter: #{job['company']['twitter']}</p>" +
+                "<p>Salary: #{job['salary']}</p>" +
+                "<p>How to apply: #{job['how_to_apply']}</p>" +
+                "<p>Contact: #{job['contact_email']}</p>" +
+                "<p>Link: <a href='#{job['link']}'>#{job['link']}</a></p>" +
+                "<p><a href='http://api.vlctechhub.org/v1/jobs/unpublish/#{job['publish_id']}/secret/#{job['secret']}'>Retirar Oferta</a></p>"
+            end
+          end
+        end
       end
     end
   end

--- a/app/jobs.rb
+++ b/app/jobs.rb
@@ -28,6 +28,7 @@ module VLCTechHub
         j['published'] = false
         j['publish_id'] = SecureRandom.uuid
         j['created_at'] = DateTime.now
+        j['secret'] = SecureRandom.uuid
       }
     end
   end

--- a/spec/app/base/repository_spec.rb
+++ b/spec/app/base/repository_spec.rb
@@ -21,4 +21,29 @@ describe VLCTechHub::Base::Repository do
       expect(updated['published_at']).not_to be_nil
     end
   end
+
+  describe '#unpublish' do
+
+    it 'fail to unpublish when secret is wrong' do
+      job = { published: true, publish_id: 456, secret: 'the_secret' }
+      id = subject.db['jobs'].insert_one(job).inserted_id
+
+      subject.unpublish(456, 'wrong_secret')
+
+      updated = subject.db['jobs'].find({ _id: id }).first
+      expect(updated['published']).to eql(true)
+    end
+
+    it 'flags the record as not published' do
+      job = { published: true, publish_id: 678, secret: 'the_secret' }
+      id = subject.db['jobs'].insert_one(job).inserted_id
+
+      subject.unpublish(678, 'the_secret')
+
+      updated = subject.db['jobs'].find({ _id: id }).first
+      expect(updated['published']).to eql(false)
+    end
+
+  end
+
 end

--- a/spec/app/base/repository_spec.rb
+++ b/spec/app/base/repository_spec.rb
@@ -35,13 +35,13 @@ describe VLCTechHub::Base::Repository do
     end
 
     it 'flags the record as not published' do
-      job = { published: true, publish_id: 678, secret: 'the_secret' }
+      job = { published: true, publish_id: 678, secret: 'the_secret', published_at: DateTime.now }
       id = subject.db['jobs'].insert_one(job).inserted_id
 
       subject.unpublish(678, 'the_secret')
 
       updated = subject.db['jobs'].find({ _id: id }).first
-      expect(updated['published']).to eql(false)
+      expect(updated['published_at']).to be_nil
     end
 
   end

--- a/spec/app/job/mailer_spec.rb
+++ b/spec/app/job/mailer_spec.rb
@@ -9,7 +9,8 @@ describe VLCTechHub::Job::Mailer do
     'title' => 'a title',
     'description' => 'a description',
     'company' => { 'name' => 'canal cocina'},
-    'link' => 'http://anywhere.org' }
+    'link' => 'http://anywhere.org',
+    'contact_email' => 'pub@email.any'}
   }
 
   describe '#publish' do
@@ -50,6 +51,21 @@ describe VLCTechHub::Job::Mailer do
       html_body = mail.body.parts.first.body.raw_source
       expect(html_body).to include(job['link'])
       expect(html_body).to include(job['company']['name'])
+    end
+  end
+
+  describe '#published' do
+
+    it 'delivers a formatted mail with unpublish link' do
+      described_class.published job
+
+      mail = Mail::TestMailer.deliveries.first
+      expect(mail.from).to eq(['vlctechhub@gmail.com'])
+      expect(mail.to).to eq(['pub@email.any'])
+      expect(mail.subject).to include(job['title'])
+      html_body = mail.body.parts.first.body.raw_source
+      expect(html_body).to include(job['link'])
+      expect(html_body).to include('unpublish')
     end
   end
 end

--- a/spec/app/jobs_spec.rb
+++ b/spec/app/jobs_spec.rb
@@ -16,6 +16,7 @@ describe VLCTechHub::Jobs do
       expect(result['published']).to eql(false)
       expect(result['publish_id']).not_to be_nil
       expect(result['created_at']).not_to be_nil
+      expect(result['secret']).not_to be_nil
     end
   end
 end

--- a/spec/routes/jobs_spec.rb
+++ b/spec/routes/jobs_spec.rb
@@ -108,7 +108,7 @@ describe VLCTechHub::API::V1::Routes do
   end
 
   describe 'GET /v1/jobs/unpublish' do
-    context 'Job is not found' do
+    context 'Job is found' do
 
       it 'returns 404 if found but wrong secret' do
         job = VLCTechHub::Jobs.new.insert({text: 'javascript rockstar'})
@@ -119,16 +119,12 @@ describe VLCTechHub::API::V1::Routes do
 
     context 'Unpublish a job' do
 
-      job = VLCTechHub::Jobs.new.insert({text: 'javascript rockstar'})
-
-      it 'publishes the record' do
-        get "/v1/jobs/publish/#{job['publish_id'].to_s}"
-        expect(last_response).to be_ok
-      end
-
-      it 'updates publishes the record' do
+      job = VLCTechHub::Jobs.new.insert({published: true, text: 'javascript rockstar', published_at: DateTime.now})
+      it 'flags the job as not published' do
         get "/v1/jobs/unpublish/#{job['publish_id'].to_s}/secret/#{job['secret'].to_s}"
         expect(last_response).to be_ok
+        expect(response_job['published_at']).to be_nil
+
       end
     end
   end


### PR DESCRIPTION
#34 I have added the unpublish functionality for jobs.
- Added a new _secret_ field to the model.
- Added a new _unpublish_ endpoint that is composed by the published_id and the secret field.
- Added a new _published_ method for the Mailer that sends the unpublish link to the jobOffer owner
