### PR TITLE
Check for a blank string in the job additional link

### DIFF
--- a/lib/job/repository.rb
+++ b/lib/job/repository.rb
@@ -35,7 +35,7 @@ module VLCTechHub
       end
 
       def correct(job)
-        return job if job[:link].blank?
+        return job if job[:link].nil? || job[:link].empty?
 
         link_misses_protocol = !job[:link].match(%r{^https?://})
         job[:link] = "http://#{job[:link]}" if link_misses_protocol

--- a/lib/job/repository.rb
+++ b/lib/job/repository.rb
@@ -35,7 +35,7 @@ module VLCTechHub
       end
 
       def correct(job)
-        return job if job[:link].nil?
+        return job if job[:link].blank?
 
         link_misses_protocol = !job[:link].match(%r{^https?://})
         job[:link] = "http://#{job[:link]}" if link_misses_protocol

--- a/spec/lib/job/repository_spec.rb
+++ b/spec/lib/job/repository_spec.rb
@@ -33,6 +33,11 @@ describe VLCTechHub::Job::Repository do
       result = repo.insert(link: 'http://www.vlcjob.es')
       expect(result['link']).to eql('http://www.vlcjob.es')
     end
+
+    it 'does not add protocol to link when empty' do
+      result = repo.insert(link: '')
+      expect(result['link']).to eql('')
+    end
   end
 
   describe '#find_twitter_pending_jobs' do


### PR DESCRIPTION
The `blank` checks for `nil` and `''`, so if the link is left empty it does not get transformed.